### PR TITLE
fix：kaminariの翻訳を追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -259,6 +259,11 @@ body {
   }
 }
 
+.page-item.disabled .page-link {
+  color: $third-color-gray !important;
+  background-color: $second-color-green !important;
+}
+
 .page-item.active .page-link {
   color: $third-color-gray !important;
   background-color: $primary-color-green !important;

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "First"
+      last: "Last"
+      previous: "Previous"
+      next: "Next"
+      truncate: "..."


### PR DESCRIPTION
・「truncate: "..."」の翻訳がなく、英単語がそのまま表示されていた